### PR TITLE
Fix apache dependencies

### DIFF
--- a/tasks/pkg.yml
+++ b/tasks/pkg.yml
@@ -3,6 +3,7 @@
   apt: pkg={{ item }} state={{ passenger_pkgs_state }}
   with_items:
     - libapache2-mod-passenger
+    - apache2
   notify: apache restart
   when: passenger_webserver == "apache"
 
@@ -31,3 +32,4 @@
     - /usr/sbin/passenger-memory-stats
     - /usr/sbin/passenger-status
   when: passenger_pkgs_fix_shebang
+

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -10,10 +10,6 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--memory", 512]
   end
 
-  config.vm.provision :shell do |shell|
-    shell.inline = "sudo apt-get update && apt-get --yes install python-pycurl"
-  end
-
   config.vm.define "apache" do |apache|
     apache.vm.hostname = "passenger-apache"
     apache.vm.network :forwarded_port, guest: 80, host: 8080

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -3,8 +3,7 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "opscode-debian-7.2.0"
-  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.2.0_chef-provisionerless.box"
+  config.vm.box = "boxcutter/ubuntu1404"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]

--- a/tests/apache/apache.yml
+++ b/tests/apache/apache.yml
@@ -6,6 +6,11 @@
   - passenger_pkgs_state: "latest"
   - passenger_pkgs_fix_shebang: yes
 
+  pre_tasks:
+    - name: tests - install python-pycurl
+      apt: pkg=python-pycurl state=latest
+      sudo: yes
+
   roles:
     - { role: ../../../, sudo: yes }
 
@@ -23,18 +28,19 @@
       notify: apache restart
 
     - name: tests - add hello_world webserver site config
-      template: src=hello_world.j2 dest=/etc/apache2/sites-enabled/hello_world
+      template: src=hello_world.j2 dest=/etc/apache2/sites-enabled/hello_world.conf
       notify: apache restart
       sudo: yes
 
 - hosts: all
-  connection: local
+  #connection: local
 
   tasks:
     - name: tests - check site availability and content
-      shell: wget --no-verbose -O - http://localhost:8080
-      register: reg_wget
+      command: curl -si http://localhost
+      register: site_availability
 
     - name: tests - check site result
-      debug: var=reg_wget
-      failed_when: "'hello world' not in reg_wget.stdout"
+      debug: var=site_availability
+      failed_when: "'hello world' not in site_availability.stdout"
+

--- a/tests/apache/hello_world.j2
+++ b/tests/apache/hello_world.j2
@@ -1,8 +1,14 @@
+PassengerEnabled on
+
 <VirtualHost *:80>
     ServerName localhost
+
     DocumentRoot {{ ansible_env.HOME }}/hello_world/public
+
     <Directory {{ ansible_env.HOME }}/hello_world/public>
         Allow from all
         Options -MultiViews
+        Require all granted
     </Directory>
 </VirtualHost>
+


### PR DESCRIPTION
On newer 5.x versions of Passenger's `libapache2-mod-passenger` package, the `apache2` package is no longer a requirement. That is the package that contains the apache's init scripts. As such, our installation of apache was incomplete and we could not start the service from our role.

This PR fixes that and also updates tests on apache.
