### PR TITLE
Fix deprecation warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 passenger_webserver: "standalone"
-passenger_pkgs_state: "installed"
+passenger_pkgs_state: present
 passenger_pkgs_fix_shebang: no

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -7,13 +7,10 @@
 
 - name: apt - add support for https
   apt:
-    pkg: "{{ item }}"
+    pkg: [apt-transport-https, ca-certificates]
     update_cache: yes
     cache_valid_time: 3600
     state: "{{ passenger_pkgs_state }}"
-  with_items:
-  - apt-transport-https
-  - ca-certificates
 
 - name: apt - add passenger repo
   apt_repository:

--- a/tasks/pkg.yml
+++ b/tasks/pkg.yml
@@ -1,29 +1,21 @@
 ---
 - name: pkg - install apache passenger packages
   apt:
-    pkg: "{{ item }}"
+    pkg: [libapache2-mod-passenger, apache2]
     state: "{{ passenger_pkgs_state }}"
-  with_items:
-    - libapache2-mod-passenger
-    - apache2
   notify: apache restart
   when: passenger_webserver == "apache"
 
 - name: pkg - install nginx passenger packages
   apt:
-    pkg: "{{ item }}"
+    pkg: [nginx-extras, passenger]
     state: "{{ passenger_pkgs_state }}"
-  with_items:
-    - nginx-extras
-    - passenger
   notify: nginx restart
   when: passenger_webserver == "nginx"
 
 - name: pkg - install standalone passenger packages
   apt:
-    pkg: "{{ item }}"
+    pkg: passenger
     state: "{{ passenger_pkgs_state }}"
-  with_items:
-    - passenger
   when: passenger_webserver == "standalone"
 


### PR DESCRIPTION
Two issues in this role cause the generation of warning from ansible:

- The “installed” state is deprecated in favor of “present” ;
- Calling the apt module in a loop is less efficient than passing a
list.

This patch fixes both.